### PR TITLE
Set `isIncomplete` flag on completion item in addition to in the metadata

### DIFF
--- a/src/_language-service.ts
+++ b/src/_language-service.ts
@@ -395,6 +395,7 @@ function translateCompletionItemsToCompletionInfo(
             isIncomplete: items.isIncomplete,
         },
         isGlobalCompletion: false,
+        isIncomplete: items.isIncomplete || undefined,
         isMemberCompletion: false,
         isNewIdentifierLocation: false,
         entries: items.items.map((x) => translateCompetionEntry(typescript, x, doc, wrapper)),


### PR DESCRIPTION
`isIncomplete` is currently being set on the metadata for the completion items from Emmet, but this doesn't work when using Neovim with nvim-cmp which looks for `isIncomplete` on the actual completion item, rather than in the metadata.

The field is available in the TS definition for `ts.CompletionInfo` so this seems like an acceptable change.