### PR TITLE
Correct plugin name in README.md docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Finally add a `plugins` section to your [`tsconfig.json`](http://www.typescriptl
     "compilerOptions": {
         "plugins": [
             {
-                "name": "typescript-styled-plugin"
+                "name": "@styled/typescript-styled-plugin"
             }
         ]
     }
@@ -162,7 +162,7 @@ To disable error reporting, set `"validate": false` in the plugin configuration:
     "compilerOptions": {
         "plugins": [
             {
-                "name": "typescript-styled-plugin",
+                "name": "@styled/typescript-styled-plugin",
                 "validate": false
             }
         ]
@@ -177,7 +177,7 @@ You can also configure how errors are reported using linter settings.
     "compilerOptions": {
         "plugins": [
             {
-                "name": "typescript-styled-plugin",
+                "name": "@styled/typescript-styled-plugin",
                 "lint": {
                     "vendorPrefix": "error",
                     "zeroUnits": "ignore"


### PR DESCRIPTION
The docs currently use two different plugin names in the configuration examples. I had to use the `@styled/` prefix in order to get the config to work for me in VSCode.

**Important note:** I haven't tested in Sublime to confirm that the new plugin name is also correct, just making an assumption.